### PR TITLE
Place Theme wrapper in own folder & add defaults

### DIFF
--- a/frontend/src/components/App/App.js
+++ b/frontend/src/components/App/App.js
@@ -2,15 +2,12 @@ import "./App.css";
 import NavBar from "../NavBar/NavBar";
 import Body from "../Body/Body";
 import Footer from "../Footer/Footer";
-import { createMuiTheme, ThemeProvider } from "@material-ui/core";
+
 import React, { useEffect, useState } from "react";
 import { getAll } from '../../services/book';
 import axios from 'axios';
-const theme = createMuiTheme({
-  typography: {
-    fontSize: 14,
-  }
-});
+import { Theme } from '../../theme-style/materialtheme'
+
 
 function App() {
   
@@ -22,11 +19,11 @@ function App() {
 
 
   return (
-    <ThemeProvider theme={theme}>
+    <Theme>
       <NavBar />
       <Body />
       <Footer />
-    </ThemeProvider>
+    </Theme>
     
   );
 }

--- a/frontend/src/components/App/App.js
+++ b/frontend/src/components/App/App.js
@@ -6,7 +6,7 @@ import Footer from "../Footer/Footer";
 import React, { useEffect, useState } from "react";
 import { getAll } from '../../services/book';
 
-import axios from 'axios';
+// import axios from 'axios'; // Uncommented for a moment
 import { Theme } from '../../theme-style/materialtheme'
 
 function App() {

--- a/frontend/src/theme-style/materialtheme.js
+++ b/frontend/src/theme-style/materialtheme.js
@@ -9,7 +9,7 @@ const Theme = ({children}) => {
             }
         },
         typography: {
-            fontFamily: ['"Poppins"'],
+            fontFamily: ['"Roboto"'],
             fontSize: 14,
             h2: {
                 fontWeight: 750

--- a/frontend/src/theme-style/materialtheme.js
+++ b/frontend/src/theme-style/materialtheme.js
@@ -1,0 +1,27 @@
+import { createMuiTheme, ThemeProvider } from "@material-ui/core";
+
+const Theme = ({children}) => {
+
+    const theme = createMuiTheme({
+        palette: {
+            primary: {
+                main: "#2F1160"
+            }
+        },
+        typography: {
+            fontFamily: ['"Poppins"'],
+            fontSize: 14,
+            h2: {
+                fontWeight: 750
+            }
+        }
+    });
+
+    return (
+        <ThemeProvider theme={theme}>
+            {children}
+        </ThemeProvider>
+    )
+};
+
+export { Theme }


### PR DESCRIPTION
Not sure if it's best practice or not, but I moved createMuiTheme, ThemeProvider and the component to its own folder and file for code splitting the styling and out of App.js to make it cleaner & clearer that all default theme changes to Material UI can occur in this file frontend/src/theme-style/materialtheme.js

I also added some theme changes for primary color, font-family, and h2 fontweight based on specs from Figma

@EugeneGohh let me know if you think this isn't a good idea or I got something else wrong